### PR TITLE
Improve RNG support and generation reproduciblity

### DIFF
--- a/czone/generator/amorphous_algorithms.py
+++ b/czone/generator/amorphous_algorithms.py
@@ -73,7 +73,7 @@ def gen_p_substrate(dims: List[float],
                     min_dist: float = 1.4,
                     density=.1103075,
                     print_progress=False,
-                    seed=0):
+                    rng=np.random.default_rng()):
     """Generate a uniformly random distributed collection of atoms with PBC.
 
     Given the size of a rectangular prism, a minimum bond distance, and a target
@@ -104,7 +104,6 @@ def gen_p_substrate(dims: List[float],
     """
 
     # get number of carbon atoms to generate
-    rng = np.random.default_rng(seed=seed)
     dims = np.array(dims)
     min_dist_2 = min_dist**2.0
     dim_x = dims[0]
@@ -163,9 +162,7 @@ def gen_p_substrate_batched(dims: List[float],
                     print_progress=False,
                     voxel_scale = 2.0,
                     batch_size = 16,
-                    seed = 0):
-
-    rng = np.random.default_rng(seed=seed)
+                    rng=np.random.default_rng()):
 
     # get number of carbon atoms to generate
     dims = np.array(dims)

--- a/czone/generator/amorphous_algorithms.py
+++ b/czone/generator/amorphous_algorithms.py
@@ -73,7 +73,7 @@ def gen_p_substrate(dims: List[float],
                     min_dist: float = 1.4,
                     density=.1103075,
                     print_progress=False,
-                    rng=np.random.default_rng()):
+                    rng=None):
     """Generate a uniformly random distributed collection of atoms with PBC.
 
     Given the size of a rectangular prism, a minimum bond distance, and a target
@@ -102,6 +102,8 @@ def gen_p_substrate(dims: List[float],
     Returns:
         np.ndarray: coordinates of atoms in periodic substrate
     """
+
+    rng = np.random.default_rng() if rng is None else rng
 
     # get number of carbon atoms to generate
     dims = np.array(dims)
@@ -162,8 +164,10 @@ def gen_p_substrate_batched(dims: List[float],
                     print_progress=False,
                     voxel_scale = 2.0,
                     batch_size = 16,
-                    rng=np.random.default_rng()):
+                    rng=None):
 
+    rng = np.random.default_rng() if rng is None else rng
+    
     # get number of carbon atoms to generate
     dims = np.array(dims)
     min_dist_2 = min_dist**2.0

--- a/czone/generator/generator.py
+++ b/czone/generator/generator.py
@@ -344,7 +344,7 @@ class AmorphousGenerator(BaseGenerator):
 
     """
 
-    def __init__(self, origin=None, min_dist=1.4, density=.1103075, species=6):
+    def __init__(self, origin=None, min_dist=1.4, density=.1103075, species=6, rng=np.random.default_rng()):
         self._origin = None
         self._species = None
         self._density = None
@@ -358,6 +358,7 @@ class AmorphousGenerator(BaseGenerator):
         self.min_dist = min_dist
         self.density = density
         self.use_old_result = False
+        self.rng = rng
 
     """
     Properties
@@ -408,6 +409,19 @@ class AmorphousGenerator(BaseGenerator):
         """Atomic coordinates of previous generation, if supply atoms has been called."""
         return self._old_result
 
+    @property
+    def rng(self):
+        """Random number generator associated with Generator"""
+        return self._rng
+    
+    @rng.setter
+    def rng(self, new_rng : np.random.BitGenerator):
+        if not isinstance(new_rng, np.random.Generator):
+            raise TypeError("Must supply a valid Numpy Generator")
+        
+        self._rng = new_rng
+
+
     """
     Methods
     """
@@ -416,8 +430,9 @@ class AmorphousGenerator(BaseGenerator):
         if self.use_old_result and self._old_result is not None:
             return self.old_result
         else:
+            #TODO: switch to batching/add a flag to control whether or not to batch generation
             coords = gen_p_substrate(
-                np.max(bbox, axis=0) - np.min(bbox, axis=0), self.min_dist, self.density, **kwargs)
+                np.max(bbox, axis=0) - np.min(bbox, axis=0), self.min_dist, self.density, rng=self.rng, **kwargs)
             self._old_result = (coords, np.ones(coords.shape[0]) * self.species)
             return self.old_result
 
@@ -429,7 +444,7 @@ class NullGenerator(BaseGenerator):
     nanostructures, Generators contain information about the arrangement of atoms
     in space and can supply atoms at least where they should exist. 
 
-    The NulLGenerator object handles empty space.
+    The NullGenerator object handles empty space.
     """
 
     def __init__(self):

--- a/czone/generator/generator.py
+++ b/czone/generator/generator.py
@@ -344,7 +344,7 @@ class AmorphousGenerator(BaseGenerator):
 
     """
 
-    def __init__(self, origin=None, min_dist=1.4, density=.1103075, species=6, rng=np.random.default_rng()):
+    def __init__(self, origin=None, min_dist=1.4, density=.1103075, species=6, rng=None):
         self._origin = None
         self._species = None
         self._density = None
@@ -358,7 +358,7 @@ class AmorphousGenerator(BaseGenerator):
         self.min_dist = min_dist
         self.density = density
         self.use_old_result = False
-        self.rng = rng
+        self.rng = np.random.default_rng() if rng is None else rng
 
     """
     Properties

--- a/czone/surface/adsorbate.py
+++ b/czone/surface/adsorbate.py
@@ -23,6 +23,8 @@ from ..transform import rot_v, rot_vtv, Rotation, Translation
 from pymatgen.core import Element
 from scipy.sparse import csr_matrix
 
+import warnings
+
 def sparse_matrix_from_tri(simplices):
     """Convert array of triangulation simplices into sparse matrix (graph).
     
@@ -152,6 +154,7 @@ def add_adsorbate(mol: BaseMolecule,
                   filters={},
                   debug=False,
                   use_sampling=True,
+                  rng=np.random.default_rng(),
                   **kwargs):
     """Add adsorbate onto surface of a given volume.
 
@@ -178,21 +181,17 @@ def add_adsorbate(mol: BaseMolecule,
 
     mol_out = mol.from_molecule()
 
+    if volume.atoms is None:
+        warnings.warn("Input Volume has not populated its atoms. Populating now.")
+        volume.populate_atoms()
+
     ##  Find all atoms on surface with alpha shape
     ## TODO: test default probe radius from RDF measurement
-
-    if "seed" in kwargs.keys():
-        seed = kwargs["seed"]
-    else:
-        seed = np.random.randint(0,10000)
-
-    rng = np.random.default_rng(seed=seed)
 
     if use_sampling:
         surface_ind, shape_dict = alpha_shape_alg_3D_with_sampling(points=volume.atoms, 
                                                     probe_radius=probe_radius,
                                                     N_samples=20,
-                                                    seed=seed,
                                                     rng=rng,
                                                     return_alpha_shape=True)
     else:

--- a/czone/surface/adsorbate.py
+++ b/czone/surface/adsorbate.py
@@ -48,7 +48,7 @@ def sparse_matrix_from_tri(simplices):
 
     return csr_matrix(mat)
 
-def find_approximate_normal(points, decay=0.99, tol=1e-5, margin=0, seed=23, max_steps=1000, **kwargs):
+def find_approximate_normal(points, decay=0.99, tol=1e-5, margin=0, max_steps=1000, rng=np.random.default_rng(), **kwargs):
     """Use modified perception algorithm to find approximate surface normal to set of points.
     
     Assumes points come from local section of alpha-shape, i.e, they are bounded
@@ -66,8 +66,6 @@ def find_approximate_normal(points, decay=0.99, tol=1e-5, margin=0, seed=23, max
     Returns:
         np.ndarray: (3,) normalized vector representing orientation of surface normal
     """
-
-    rng = np.random.default_rng(seed=seed)
 
     A = points # use matrix notation
 
@@ -245,8 +243,7 @@ def add_adsorbate(mol: BaseMolecule,
     best_margin = 0
     j = 0
     while(j < 10):
-        cur_seed = rng.integers(0,10000,1)[0]
-        w = find_approximate_normal(nn_pos, decay=0.95, tol=1e-4, margin=best_margin, seed=cur_seed)
+        w = find_approximate_normal(nn_pos, decay=0.95, tol=1e-4, margin=best_margin, rng=rng)
 
         margins = []
         for b in nn_pos:

--- a/czone/surface/adsorbate.py
+++ b/czone/surface/adsorbate.py
@@ -50,7 +50,7 @@ def sparse_matrix_from_tri(simplices):
 
     return csr_matrix(mat)
 
-def find_approximate_normal(points, decay=0.99, tol=1e-5, margin=0, max_steps=1000, rng=np.random.default_rng(), **kwargs):
+def find_approximate_normal(points, decay=0.99, tol=1e-5, margin=0, max_steps=1000, rng=None, **kwargs):
     """Use modified perception algorithm to find approximate surface normal to set of points.
     
     Assumes points come from local section of alpha-shape, i.e, they are bounded
@@ -68,6 +68,8 @@ def find_approximate_normal(points, decay=0.99, tol=1e-5, margin=0, max_steps=10
     Returns:
         np.ndarray: (3,) normalized vector representing orientation of surface normal
     """
+
+    rng = np.random.default_rng() if rng is None else rng
 
     A = points # use matrix notation
 
@@ -154,7 +156,7 @@ def add_adsorbate(mol: BaseMolecule,
                   filters={},
                   debug=False,
                   use_sampling=True,
-                  rng=np.random.default_rng(),
+                  rng=None,
                   **kwargs):
     """Add adsorbate onto surface of a given volume.
 
@@ -178,6 +180,8 @@ def add_adsorbate(mol: BaseMolecule,
     Returns:
         Adsorbate molecule 
     """
+
+    rng = np.random.default_rng() if rng is None else rng
 
     mol_out = mol.from_molecule()
 

--- a/czone/surface/alpha_shape.py
+++ b/czone/surface/alpha_shape.py
@@ -110,7 +110,7 @@ def alpha_shape_alg_3D(points, probe_radius, return_alpha_shape=False):
         return list(set(out_points))
 
 
-def alpha_shape_alg_3D_with_sampling(points, probe_radius, N_samples, std=1e-4, rng = None, seed = None, return_alpha_shape=False):
+def alpha_shape_alg_3D_with_sampling(points, probe_radius, N_samples, std=1e-4, return_alpha_shape=False, rng = np.random.default_rng()):
     """Use alpha shape algorithm to determine points on exterior of collection of points.
 
     Performs alpha-shape algorithm ##TODO: cite a source here
@@ -122,14 +122,6 @@ def alpha_shape_alg_3D_with_sampling(points, probe_radius, N_samples, std=1e-4, 
     Returns:
         List of indices of points on exterior of surface for given alpha-shape.
     """
-
-
-    if seed is None:
-        seed = np.random.randint(0,10000)
-
-    if rng is None:
-        rng = np.random.default_rng(seed=seed)
-
     
     ## Get alpha-shape
     # get delaunay triangulation of points

--- a/czone/surface/alpha_shape.py
+++ b/czone/surface/alpha_shape.py
@@ -110,7 +110,7 @@ def alpha_shape_alg_3D(points, probe_radius, return_alpha_shape=False):
         return list(set(out_points))
 
 
-def alpha_shape_alg_3D_with_sampling(points, probe_radius, N_samples, std=1e-4, return_alpha_shape=False, rng = np.random.default_rng()):
+def alpha_shape_alg_3D_with_sampling(points, probe_radius, N_samples, std=1e-4, return_alpha_shape=False, rng = None):
     """Use alpha shape algorithm to determine points on exterior of collection of points.
 
     Performs alpha-shape algorithm ##TODO: cite a source here
@@ -122,6 +122,8 @@ def alpha_shape_alg_3D_with_sampling(points, probe_radius, N_samples, std=1e-4, 
     Returns:
         List of indices of points on exterior of surface for given alpha-shape.
     """
+
+    rng = np.random.default_rng() if rng is None else rng
     
     ## Get alpha-shape
     # get delaunay triangulation of points

--- a/czone/transform/post.py
+++ b/czone/transform/post.py
@@ -35,20 +35,19 @@ class BasePostTransform(ABC):
 
 class ChemicalSubstitution(BasePostTransform):
 
-    def __init__(self, target, substitute, frac):
-        assert(len(target) == len(substitute))
-        self.target = target
-        self.substitute = substitute
+    def __init__(self, mapping : dict, frac, rng=np.random.default_rng()):
+        self.target = mapping.keys()
+        self.substitute = mapping.values()
         self.frac = frac
+        self.rng = rng
 
-    def _replace_species(self, species, seed=None):
+    def _replace_species(self, species):
 
         out_species = np.copy(species)
-        rng = np.random.default_rng(seed=seed)
 
         for t, s in zip(self.target, self.substitute):
             t_filter = species == t
-            t_probs = rng.uniform(0,1,size=species.shape)
+            t_probs = self.rng.uniform(0,1,size=species.shape)
 
             out_species[(t_filter) & (t_probs <= self.frac)] = s
 
@@ -56,6 +55,19 @@ class ChemicalSubstitution(BasePostTransform):
 
     def apply_function(self, points: np.ndarray, species: np.ndarray, **kwargs):
         return points, self._replace_species(species, **kwargs)
+        
+    @property
+    def rng(self):
+        """Random number generator associated with Generator"""
+        return self._rng
+    
+    @rng.setter
+    def rng(self, new_rng : np.random.BitGenerator):
+        if not isinstance(new_rng, np.random.Generator):
+            raise TypeError("Must supply a valid Numpy Generator")
+        
+        self._rng = new_rng
+
 
 
 class ArbitraryPostTransform(BasePostTransform):

--- a/czone/transform/post.py
+++ b/czone/transform/post.py
@@ -35,11 +35,11 @@ class BasePostTransform(ABC):
 
 class ChemicalSubstitution(BasePostTransform):
 
-    def __init__(self, mapping : dict, frac, rng=np.random.default_rng()):
+    def __init__(self, mapping : dict, frac, rng=None):
         self.target = mapping.keys()
         self.substitute = mapping.values()
         self.frac = frac
-        self.rng = rng
+        self.rng = np.random.default_rng() if rng is None else rng
 
     def _replace_species(self, species):
 

--- a/czone/util/misc.py
+++ b/czone/util/misc.py
@@ -16,7 +16,7 @@ def round_away(x: float) -> float:
     return np.sign(x) * np.ceil(np.abs(x))
 
 
-def get_N_splits(n: int, m: int, l: int, seed: int = None) -> List[int]:
+def get_N_splits(n: int, m: int, l: int, rng = np.random.default_rng()) -> List[int]:
     """Get N uniform random integers in interval [M,L-M) with separation M.
 
     Args:
@@ -33,9 +33,8 @@ def get_N_splits(n: int, m: int, l: int, seed: int = None) -> List[int]:
         
     if (l - 2 * m < (n - 1) * m):
         raise ValueError("m is too large for number of splits requested and l")
-    rng = np.random.default_rng(seed=seed)
 
-    #seed an initial choice and create array to calculate distances in
+    # seed an initial choice and create array to calculate distances in
     splits = [rng.integers(m, l - m)]
     data = np.array([x for x in range(m, l - m)])
     idx = np.ma.array(data=data, mask=np.abs(data - splits[-1]) < m)

--- a/czone/util/misc.py
+++ b/czone/util/misc.py
@@ -16,7 +16,7 @@ def round_away(x: float) -> float:
     return np.sign(x) * np.ceil(np.abs(x))
 
 
-def get_N_splits(n: int, m: int, l: int, rng = np.random.default_rng()) -> List[int]:
+def get_N_splits(n: int, m: int, l: int, rng = None) -> List[int]:
     """Get N uniform random integers in interval [M,L-M) with separation M.
 
     Args:
@@ -34,6 +34,8 @@ def get_N_splits(n: int, m: int, l: int, rng = np.random.default_rng()) -> List[
     if (l - 2 * m < (n - 1) * m):
         raise ValueError("m is too large for number of splits requested and l")
 
+    rng = np.random.default_rng() if rng is None else rng
+    
     # seed an initial choice and create array to calculate distances in
     splits = [rng.integers(m, l - m)]
     data = np.array([x for x in range(m, l - m)])

--- a/czone/volume/volume.py
+++ b/czone/volume/volume.py
@@ -164,9 +164,8 @@ class Volume(BaseVolume):
 
         self.priority = priority
 
-        if not (alg_objects is None):
-            for obj in alg_objects:
-                self.add_alg_object(obj)
+        if alg_objects is not None:
+            self.add_alg_object(alg_objects)
 
     """
     Properties
@@ -196,9 +195,15 @@ class Volume(BaseVolume):
         Args:
             obj (BaseAlgebraic): Algebraic surface to add to volume.
         """
-        assert (
-            isinstance(obj, (BaseAlgebraic))
-        ), "Must be adding algebraic objects from derived BaseAlgebraic class"
+        try:
+            ob_iter = iter(obj)
+        except TypeError:
+            ob_iter = iter([obj])
+
+        for ob in ob_iter:
+            if not isinstance(obj, BaseAlgebraic):
+                raise TypeError("Must be adding algebraic objects from derived BaseAlgebraic class")
+            
         self._alg_objects.append(copy.deepcopy(obj))
 
     @property

--- a/czone/volume/volume.py
+++ b/czone/volume/volume.py
@@ -200,11 +200,13 @@ class Volume(BaseVolume):
         except TypeError:
             ob_iter = iter([obj])
 
+        ob_copies = []
         for ob in ob_iter:
-            if not isinstance(obj, BaseAlgebraic):
+            if not isinstance(ob, BaseAlgebraic):
                 raise TypeError("Must be adding algebraic objects from derived BaseAlgebraic class")
+            ob_copies.append(copy.deepcopy(ob))
             
-        self._alg_objects.append(copy.deepcopy(obj))
+        self._alg_objects.extend(ob_copies)
 
     @property
     def hull(self):

--- a/tests/test_rng.py
+++ b/tests/test_rng.py
@@ -3,6 +3,10 @@ import unittest
 import numpy as np
 import pytest
 
+from czone.generator.amorphous_algorithms import (
+    gen_p_substrate,
+    gen_p_substrate_batched,
+)
 from czone.molecule import Molecule
 from czone.surface import (
     add_adsorbate,
@@ -93,6 +97,20 @@ class Test_Functions(unittest.TestCase):
         for _ in range(self.N_trials):
             seed = base_rng.integers(0, int(1e6))
             self.assertConsistent(alpha_shape_alg_3D_with_sampling, (test_points, probe_radius, N_samples), seed)
+
+    def test_gen_p_substrate(self):
+        dims = (20,20,20)
+
+        for _ in range(self.N_trials):
+            seed = base_rng.integers(0, int(1e6))
+            self.assertConsistent(gen_p_substrate, (dims,), seed)
+
+    def test_gen_p_substrate_batched(self):
+        dims = (20,20,20)
+
+        for _ in range(self.N_trials):
+            seed = base_rng.integers(0, int(1e6))
+            self.assertConsistent(gen_p_substrate_batched, (dims,), seed)
         
     
 class Test_Classes(unittest.TestCase):

--- a/tests/test_rng.py
+++ b/tests/test_rng.py
@@ -18,6 +18,7 @@ from czone.surface import (
 from czone.transform import ChemicalSubstitution
 from czone.util.misc import get_N_splits
 from czone.volume import Sphere, Volume
+from czone.prefab import fccMixedTwinSF, wurtziteStackingFault
 
 """
 These unit tests are not meant to measure code functionality/correctness.
@@ -154,5 +155,8 @@ class Test_Classes(czone_TestCase):
 
             ref_volume.populate_atoms()
             test_volume.populate_atoms()
-            self.assertArrayEqual(ref_volume.species, test_volume.species)            
+            self.assertArrayEqual(ref_volume.species, test_volume.species)
+
+    def test_fccMixedTwinSF(self):
+        pass
 

--- a/tests/test_rng.py
+++ b/tests/test_rng.py
@@ -158,5 +158,46 @@ class Test_Classes(czone_TestCase):
             self.assertArrayEqual(ref_volume.species, test_volume.species)
 
     def test_fccMixedTwinSF(self):
-        pass
+        generator = Generator.from_spacegroup([6], np.zeros((1,3)), [2, 2, 2], [90, 90, 90], sgn=225)
+        volume = Volume(alg_objects=Sphere(10, np.zeros(3)))
+
+        N_trials = 32
+        for _ in range(N_trials):
+            seed = base_rng.integers(0,int(1e6))
+            ref_rng = np.random.default_rng(seed=seed)
+            test_rng = np.random.default_rng(seed=seed)
+
+            ref_fab = fccMixedTwinSF(generator, volume, rng=ref_rng)
+            test_fab = fccMixedTwinSF(generator, volume, rng=test_rng)
+
+            ref_obj = ref_fab.build_object()
+            ref_obj.populate_atoms()
+
+            test_obj = test_fab.build_object()
+            test_obj.populate_atoms()
+
+            self.assertArrayEqual(ref_obj.atoms, test_obj.atoms)
+            self.assertArrayEqual(ref_obj.species, test_obj.species)
+
+    def test_wurtziteStackingFault(self):
+        generator = Generator.from_spacegroup([6], np.zeros((1,3)), [2, 2, 3], [90, 90, 120], sgn=186)
+        volume = Volume(alg_objects=Sphere(10, np.zeros(3)))
+
+        N_trials = 32
+        for _ in range(N_trials):
+            seed = base_rng.integers(0,int(1e6))
+            ref_rng = np.random.default_rng(seed=seed)
+            test_rng = np.random.default_rng(seed=seed)
+
+            ref_fab = wurtziteStackingFault(generator, volume, rng=ref_rng)
+            test_fab = wurtziteStackingFault(generator, volume, rng=test_rng)
+
+            ref_obj = ref_fab.build_object()
+            ref_obj.populate_atoms()
+
+            test_obj = test_fab.build_object()
+            test_obj.populate_atoms()
+
+            self.assertArrayEqual(ref_obj.atoms, test_obj.atoms)
+            self.assertArrayEqual(ref_obj.species, test_obj.species)
 

--- a/tests/test_rng.py
+++ b/tests/test_rng.py
@@ -1,0 +1,45 @@
+import unittest
+import numpy as np
+
+from czone.util.misc import get_N_splits
+
+"""
+These unit tests are not meant to measure code functionality/correctness.
+Instead, these are meant to check that any method using RNGs can be
+completely reproduced by passing the RNG in as a property/argument.
+"""
+
+seed = 9871492
+base_rng = np.random.default_rng(seed=seed)
+
+
+class Test_Functions(unittest.TestCase):
+    def setUp(self):
+        self.N_trials = 32
+
+    def assertConsistent(self, F, args, seed):        
+        # seed rng and get reference result
+        rng = np.random.default_rng(seed)
+        ref_state = rng.bit_generator.state # cache state to reseed rng
+        ref_res = F(*args, rng=rng)
+
+        # reset RNG state and call function again
+        rng.bit_generator.state = ref_state
+        test_res = F(*args, rng=rng)
+        self.assertEqual(ref_res, test_res)
+
+    def test_get_N_splits(self):
+        L = 32
+        N = 4
+        M = 2
+        for _ in range(self.N_trials):
+            seed = base_rng.integers(0, int(1e6))
+            self.assertConsistent(get_N_splits, (N, M, L), seed)
+
+
+    
+class Test_Classes(unittest.TestCase):
+    def setUp(self):
+        self.N_trials = 32
+
+


### PR DESCRIPTION
Primarily, this pull requests updates the functions and classes which rely on random number generation to be able to reproduce their results with a unified interface.

- Any function which uses an RNG now accepts `rng` as an argument. By default if no RNG is supplied, one will be initialized via numpy's `default_rng` function.
- Any class which has methods that themselves use RNGs can now store their RNG as a property
- Tests have been added to ensure reproducibility based on recreation of analogous objects

These should be relatively minimal changes which help improve the reproducibility. There is still, however, a bit of gray area of undefined/unclear behavior when class methods, such as `Generator.from_generator`, are used to instantiate new copies of objects. Right now, the RNG referred to by the Generator property will be deep copied into the new Generator object. Whether or not this is semantically consistent behavior, or requires a warning, is still a bit unclear to me. I'll decide what that behavior should look/feel like globally and implement that (alongside warnings and documentation) in a future PR.