### PR TITLE
Blueprints: mechanisms for representing and reproducing objects 

### DIFF
--- a/czone/__init__.py
+++ b/czone/__init__.py
@@ -6,3 +6,4 @@ from . import transform
 from . import prefab
 from . import surface
 from . import molecule
+from . import blueprint

--- a/czone/blueprint/__init__.py
+++ b/czone/blueprint/__init__.py
@@ -1,0 +1,2 @@
+from .blueprint import Blueprint
+from .serializer import Serializer

--- a/czone/blueprint/blueprint.py
+++ b/czone/blueprint/blueprint.py
@@ -1,10 +1,98 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+
+from abc import ABC, abstractmethod
+from collections.abc import Mapping
 
 from czone.util.eset import EqualSet
 from czone.volume import BaseVolume, Volume, MultiVolume, Voxel, Plane, Sphere, Cylinder
 from czone.scene import BaseScene, Scene, PeriodicScene
 from czone.generator import BaseGenerator, AmorphousGenerator, Generator, NullGenerator
 from czone.molecule import Molecule
+from czone.transform import BaseStrain, BasePostTransform
+
+from pymatgen.core import Structure, Lattice
+import numpy as np
+
+@dataclass(kw_only=True)
+class BaseNode(ABC, Mapping):
+    # metadata: dict = field(default_factory=dict)
+    # name: str = ''
+    children: tuple = tuple()
+
+    @property
+    @abstractmethod
+    def is_leaf(self) -> bool:
+        pass
+
+    @property
+    @abstractmethod
+    def base_type(self):
+        pass
+
+    @property
+    @abstractmethod
+    def class_type(self):
+        pass
+
+    @abstractmethod
+    def add_node(self, new_node):
+        pass
+
+    def __getitem__(self, key):
+        return self.__dict__[key]
+    
+    def __len__(self):
+        return len(self.__dict__)
+    
+    def __iter__(self):
+        yield from self.__dict__
+    
+class BaseGeneratorNode(BaseNode):
+
+    @property
+    def base_type(self):
+        return BaseGenerator
+    
+    @property
+    def class_type(self):
+        return BaseGenerator
+
+    @property
+    def is_leaf(self):
+        return True
+    
+    def add_node(self):
+        pass
+
+class NullGeneratorNode(BaseGeneratorNode):
+    @property
+    def class_type(self):
+        return NullGenerator
+
+@dataclass
+class AmorphousGeneratorNode(BaseGeneratorNode):
+    origin: np.ndarray
+    min_dist: float
+    density: float
+    species: int
+
+    @property
+    def class_type(self):
+        return AmorphousGenerator
+    
+@dataclass
+class GeneratorNode(BaseGeneratorNode):
+    origin: np.ndarray
+    lattice_matrix: np.ndarray
+    basis_species: tuple[int]
+    basis_coords: np.ndarray
+    strain_field: BaseStrain | None = None
+    post_transform: BasePostTransform | None = None
+
+    @property
+    def class_type(self):
+        return Generator
+
 
 class Blueprint():
     """
@@ -28,10 +116,31 @@ class Blueprint():
     @property
     def mapping(self):
         return self._mapping
+    
+    @mapping.setter
+    def mapping(self, node):
+        if isinstance(node, BaseNode):
+            self._mapping = node
+        else:
+            raise TypeError
 
-    def map_generator(self, G):
-        raise NotImplementedError
-        
+    def map_generator(self, G: BaseGenerator):
+        match G:
+            case NullGenerator():
+                return NullGeneratorNode()
+            case AmorphousGenerator():
+                return AmorphousGeneratorNode(G.origin, G.min_dist, G.density, G.species)
+            case Generator():
+                params = {'origin':G.origin,
+                          'lattice_matrix':G.lattice.matrix,
+                          'basis_species':G.species,
+                          'basis_coords':G.coords,
+                          'strain_field':G.strain_field,
+                          'post_transform':G.post_transform}
+                return GeneratorNode(**params)
+            case _:
+                raise NotImplementedError
+            
     def map_volume(self, V):
         # Should be recursive, to handle multivolumes
         raise NotImplementedError
@@ -49,6 +158,31 @@ class Blueprint():
                 self.mapping = self.map_scene(obj)
             case _:
                 raise TypeError()
+            
+    def inverse_map_generator(self, node: BaseGeneratorNode) -> NullGenerator | Generator | AmorphousGenerator:
+        params = {**node}
+        children = params.pop('children')
+        if len(children) != 0:
+            raise ValueError("Generator Nodes should not have children.")
+        
+        match node:
+            case NullGeneratorNode() | AmorphousGeneratorNode():
+                return node.class_type(**params)
+            case GeneratorNode():
+                lattice = Lattice(params.pop('lattice_matrix'))
+                species = params.pop('basis_species')
+                coords = params.pop('basis_coords')
+                structure = Structure(lattice, species, coords)
+                return Generator(structure=structure, **params)
+            case BaseGeneratorNode():
+                raise TypeError("Base Generators should not be constructed directly.")
+            case _:
+                raise TypeError
+
     
     def to_object(self):
-        raise NotImplementedError
+        match self.mapping:
+            case BaseGeneratorNode():
+                return self.inverse_map_generator(self.mapping)
+            case _:
+                raise NotImplementedError

--- a/czone/blueprint/blueprint.py
+++ b/czone/blueprint/blueprint.py
@@ -1,0 +1,54 @@
+from dataclasses import dataclass
+
+from czone.util.eset import EqualSet
+from czone.volume import BaseVolume, Volume, MultiVolume, Voxel, Plane, Sphere, Cylinder
+from czone.scene import BaseScene, Scene, PeriodicScene
+from czone.generator import BaseGenerator, AmorphousGenerator, Generator, NullGenerator
+from czone.molecule import Molecule
+
+class Blueprint():
+    """
+    Represents (Periodic)Scenes, (Multi)Volumes, and Generators 
+    as nested mappings.
+    """
+    def __init__(self, obj):
+        self.get_mapping(obj)
+
+    def __repr__(self, other):
+        return f"Blueprint({repr(self.to_object())})"
+
+    def __eq__(self, other):
+        if isinstance(other, Blueprint):
+            other_obj = other.to_object()
+        else:
+            other_obj = other
+
+        return self.to_object() == other_obj
+
+    @property
+    def mapping(self):
+        return self._mapping
+
+    def map_generator(self, G):
+        raise NotImplementedError
+        
+    def map_volume(self, V):
+        # Should be recursive, to handle multivolumes
+        raise NotImplementedError
+
+    def map_scene(self, S):
+        raise NotImplementedError
+
+    def get_mapping(self, obj):
+        match obj:
+            case BaseGenerator():
+                self.mapping = self.map_generator(obj)
+            case BaseVolume():
+                self.mapping = self.map_volume(obj)
+            case BaseScene():
+                self.mapping = self.map_scene(obj)
+            case _:
+                raise TypeError()
+    
+    def to_object(self):
+        raise NotImplementedError

--- a/czone/blueprint/serializer.py
+++ b/czone/blueprint/serializer.py
@@ -1,0 +1,97 @@
+from abc  import ABC, abstractmethod
+from czone.blueprint import Blueprint
+from pathlib import Path
+
+class BaseSerializer(ABC):
+    
+    def __init__():
+        pass
+
+    @staticmethod
+    @abstractmethod
+    def serialize(filepath: Path | str, blueprint: Blueprint, **kwargs) -> None:
+        """Take a Blueprint and serialize to disk."""
+        pass
+
+    @classmethod
+    def write(cls, filepath: Path | str, blueprint: Blueprint, **kwargs) -> None:
+        "Alias for serialize."
+        cls.serialize(filepath, blueprint, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def deserialize(filepath: Path | str, **kwargs) -> Blueprint:
+        """Take a file and try to return a Blueprint"""
+        pass
+
+    @classmethod
+    def read(cls, filepath: Path | str, **kwargs) -> Blueprint:
+        """Alias for deserialize."""
+        cls.deserialize(filepath, **kwargs)
+
+
+class h5_Serializer(BaseSerializer):
+
+    @staticmethod
+    def serialize(filepath: Path | str, blueprint: Blueprint, **kwargs) -> None:
+        raise NotImplementedError
+
+    @staticmethod
+    def deserialize(filepath: Path | str, **kwargs) -> Blueprint:
+        raise NotImplementedError
+
+class json_Serializer(BaseSerializer):
+
+    @staticmethod
+    def serialize(filepath: Path | str, blueprint: Blueprint, **kwargs) -> None:
+        raise NotImplementedError
+
+    @staticmethod
+    def deserialize(filepath: Path | str, **kwargs) -> Blueprint:
+        raise NotImplementedError
+
+class yaml_Serializer(BaseSerializer):
+
+    @staticmethod
+    def serialize(filepath: Path | str, blueprint: Blueprint, **kwargs) -> None:
+        raise NotImplementedError
+
+    @staticmethod
+    def deserialize(filepath: Path | str, **kwargs) -> Blueprint:
+        raise NotImplementedError
+    
+class Serializer(BaseSerializer):
+    """Dispatch class."""
+
+    @staticmethod
+    def serialize(filepath: Path | str, blueprint: Blueprint, **kwargs) -> None:
+        ## Get format from **kwargs if passed in; otherwise, infer from filepath
+        output_format = kwargs.get('format', str(filepath).rsplit('.')[-1])
+
+        match output_format:
+            case 'h5' | 'H5' | 'hdf5':
+                return h5_Serializer.serialize(filepath, blueprint, **kwargs)
+            case 'json':
+                return json_Serializer.serialize(filepath, blueprint, **kwargs)
+            case 'yaml':
+                return yaml_Serializer.serialize(filepath, blueprint, **kwargs)
+            case _:
+                raise ValueError(f"Unsupported format {output_format} detected or passed in.")
+
+    @staticmethod
+    def deserialize(filepath: Path | str, **kwargs) -> Blueprint:
+        ## Get format from **kwargs if passed in; otherwise, infer from filepath
+        input_format = kwargs.get('format', str(filepath).rsplit('.')[-1])
+
+        match input_format:
+            case 'h5' | 'H5' | 'hdf5':
+                return h5_Serializer.deserialize(filepath, **kwargs)
+            case 'json':
+                return json_Serializer.deserialize(filepath, **kwargs)
+            case 'yaml':
+                return yaml_Serializer.deserialize(filepath, **kwargs)
+            case _:
+                raise ValueError(f"Unsupported format {input_format} detected or passed in.")
+
+
+    

--- a/czone/blueprint/serializer.py
+++ b/czone/blueprint/serializer.py
@@ -160,11 +160,6 @@ class toml_Serializer(BaseSerializer):
             bdict = tomlkit.load(f).unwrap()
 
         node = json_Serializer.from_dict(bdict)
-        nd = {**node}
-        for k, v in nd.items():
-            if k == 'children':
-                continue
-            print(f'{k} : {type(v)} : {v}')
         return Blueprint(node)
 
     

--- a/czone/blueprint/serializer.py
+++ b/czone/blueprint/serializer.py
@@ -203,14 +203,23 @@ class Serializer(BaseSerializer):
         input_format = kwargs.get('format', str(filepath).rsplit('.')[-1])
 
         match input_format:
-            case 'h5' | 'H5' | 'hdf5':
-                return h5_Serializer.deserialize(filepath, **kwargs)
             case 'json':
                 return json_Serializer.deserialize(filepath, **kwargs)
+            case 'h5' | 'H5' | 'hdf5':
+                if H5PY_AVAIALBLE:
+                    return h5_Serializer.deserialize(filepath, **kwargs)
+                else:
+                    raise ValueError('hdf5 support not available. Please install h5py: https://docs.h5py.org/')
             case 'yaml':
-                return yaml_Serializer.deserialize(filepath, **kwargs)
+                if YAML_AVAILABLE:
+                    return yaml_Serializer.deserialize(filepath, **kwargs)
+                else:
+                    raise ValueError('yaml support not available. Please insall pyyaml: https://pyyaml.org')
             case 'toml':
-                return toml_Serializer.deserialize(filepath, **kwargs)
+                if TOML_AVAILABLE:
+                    return toml_Serializer.deserialize(filepath, **kwargs)
+                else:
+                    raise ValueError('toml support not available. Please insall tomlkit: https://tomlkit.readthedocs.io/en')
             case _:
                 raise ValueError(f"Unsupported format {input_format} detected or passed in.")
 

--- a/czone/blueprint/serializer.py
+++ b/czone/blueprint/serializer.py
@@ -9,6 +9,24 @@ from pathlib import Path
 import numpy as np
 import json
 
+try:
+    import yaml
+    YAML_AVAILABLE = True
+except ImportError as e:
+    YAML_AVAILABLE = False
+
+try:
+    import tomli
+    TOML_AVAILABLE = True
+except ImportError as e:
+    TOML_AVAILABLE = False
+
+try:
+    import h5py
+    H5PY_AVAIALBLE = True
+except ImportError as e:
+    H5PY_AVAIALBLE = False
+
 class BaseSerializer(ABC):
     
     def __init__():
@@ -111,11 +129,20 @@ class yaml_Serializer(BaseSerializer):
 
     @staticmethod
     def serialize(filepath: Path | str, blueprint: Blueprint, **kwargs) -> None:
-        raise NotImplementedError
+        bdict = json_Serializer.to_dict(blueprint.mapping)
+
+        with open(filepath, 'w') as f:
+            yaml.dump(bdict, f, **kwargs)
 
     @staticmethod
     def deserialize(filepath: Path | str, **kwargs) -> Blueprint:
-        raise NotImplementedError
+
+        with open(filepath, 'r') as f:
+            bdict = yaml.full_load(f)
+
+        node = json_Serializer.from_dict(bdict)
+        return Blueprint(node)
+
     
 class Serializer(BaseSerializer):
     """Dispatch class."""
@@ -131,7 +158,10 @@ class Serializer(BaseSerializer):
             case 'json':
                 return json_Serializer.serialize(filepath, blueprint, **kwargs)
             case 'yaml':
-                return yaml_Serializer.serialize(filepath, blueprint, **kwargs)
+                if YAML_AVAILABLE:
+                    return yaml_Serializer.serialize(filepath, blueprint, **kwargs)
+                else:
+                    raise ValueError('yaml support not available. Please insall pyyaml: https://pyyaml.org')
             case _:
                 raise ValueError(f"Unsupported format {output_format} detected or passed in.")
 
@@ -151,4 +181,3 @@ class Serializer(BaseSerializer):
                 raise ValueError(f"Unsupported format {input_format} detected or passed in.")
 
 
-    

--- a/czone/scene/scene.py
+++ b/czone/scene/scene.py
@@ -265,7 +265,7 @@ class PeriodicScene(BaseScene):
     @pbc.setter
     def pbc(self, val):
         if len(val) == 3:
-            if reduce(lambda x, y: x and y, [isinstance(v, bool) for v in val]):
+            if reduce(lambda x, y: x and y, [np.issubdtype(type(v), bool) for v in val]):
                 self._pbc = tuple(val)
             else:
                 raise TypeError

--- a/czone/scene/scene.py
+++ b/czone/scene/scene.py
@@ -266,7 +266,7 @@ class PeriodicScene(BaseScene):
     def pbc(self, val):
         if len(val) == 3:
             if reduce(lambda x, y: x and y, [isinstance(v, bool) for v in val]):
-                self._pbc = val
+                self._pbc = tuple(val)
             else:
                 raise TypeError
         else:

--- a/czone/volume/algebraic.py
+++ b/czone/volume/algebraic.py
@@ -121,7 +121,7 @@ class Sphere(BaseAlgebraic):
     @radius.setter
     def radius(self, radius: float):
         if radius > 0.0:
-            self._radius = radius
+            self._radius = float(radius)
         else:
             raise ValueError("Radius needs to be positive valued.")
 

--- a/czone/volume/volume.py
+++ b/czone/volume/volume.py
@@ -69,7 +69,7 @@ class BaseVolume(ABC):
         if not np.issubdtype(type(priority), np.integer):
             raise TypeError("Priority needs to be integer valued")
 
-        self._priority = priority
+        self._priority = int(priority)
 
     @abstractmethod
     def transform(self, transformation):

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -25,19 +25,23 @@ class Test_Blueprint(czone_TestCase):
         n_G = NullGenerator()
         n_blueprint = Blueprint(n_G)
         self.assertEqual(n_G, n_blueprint.to_object())
+        self.assertReprEqual(n_G)
 
         for _ in range(self.N_trials):
             a_G = get_random_amorphous_generator(rng=rng)
             a_blueprint = Blueprint(a_G)
+            self.assertReprEqual(a_G)
             self.assertEqual(a_G, a_blueprint.to_object())
 
             G = get_random_generator(rng=rng)
             blueprint = Blueprint(G)
+            self.assertReprEqual(G)
             self.assertEqual(G, blueprint.to_object())
 
     def test_volume(self):
         for _ in range(self.N_trials):
             V = get_random_volume()
+            V._alg_objects = []
             blueprint = Blueprint(V)
             self.assertEqual(V, blueprint.to_object())
 

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -65,8 +65,7 @@ class Test_Serializer(czone_TestCase):
     """blueprint -> serialized form -> blueprint"""
     def setUp(self):
         self.N_trials = 16
-        # self.formats = ['h5', 'json']
-        self.formats = ['json', 'yaml', 'toml']
+        self.formats = ['json', 'yaml', 'toml', 'h5']
         self.generator_args = {'with_strain':False, 'with_sub':False}
 
     def test_generator(self):

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -5,7 +5,7 @@ import numpy as np
 from czone.generator import NullGenerator
 
 from test_generator import get_random_generator, get_random_amorphous_generator
-from test_scene import get_random_scene
+from test_scene import get_random_scene, get_random_object
 from test_volume import get_random_volume
 
 from czone.blueprint import Blueprint, Serializer
@@ -40,8 +40,7 @@ class Test_Blueprint(czone_TestCase):
 
     def test_volume(self):
         for _ in range(self.N_trials):
-            V = get_random_volume()
-            V._alg_objects = []
+            V = get_random_object()
             blueprint = Blueprint(V)
             self.assertEqual(V, blueprint.to_object())
 

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -66,7 +66,7 @@ class Test_Serializer(czone_TestCase):
     def setUp(self):
         self.N_trials = 32
         # self.formats = ['h5', 'json']
-        self.formats = ['json']
+        self.formats = ['json', 'yaml']
         self.generator_args = {'with_strain':False, 'with_sub':False}
 
     def test_generator(self):

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -65,33 +65,37 @@ class Test_Serializer(czone_TestCase):
     """blueprint -> serialized form -> blueprint"""
     def setUp(self):
         self.N_trials = 32
-        self.formats = ['h5', 'json']
+        # self.formats = ['h5', 'json']
+        self.formats = ['json']
+        self.generator_args = {'with_strain':False, 'with_sub':False}
 
     def test_generator(self):
         for _ in range(self.N_trials):
-            G = get_random_generator()
+            G = get_random_generator(**self.generator_args)
             blueprint = Blueprint(G)
             for f in self.formats:
                 test_path = 'generator_test_file' + '.' + f
                 Serializer.write(Path(test_path), blueprint)
 
-                test_G = Serializer.read(Path(test_path)).to_object()
+                test_bp = Serializer.read(Path(test_path))
+                test_G = test_bp.to_object()
                 self.assertEqual(G, test_G)
 
     def test_volume(self):
         for _ in range(self.N_trials):
-            V = get_random_volume()
+            V = get_random_object(generator_args=self.generator_args)
             blueprint = Blueprint(V)
             for f in self.formats:
                 test_path = 'volume_test_file' + '.' + f
                 Serializer.write(Path(test_path), blueprint)
 
-                test_V = Serializer.read(Path(test_path)).to_object()
+                test_bp = Serializer.read(Path(test_path))
+                test_V = test_bp.to_object()
                 self.assertEqual(V, test_V)
 
     def test_scene(self):
         for _ in range(self.N_trials):
-            S = get_random_scene()
+            S = get_random_scene(generator_args=self.generator_args)
             blueprint = Blueprint(S)
             for f in self.formats:
                 test_path = 'scene_test_file' + '.' + f

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -7,7 +7,6 @@ from czone.volume import Voxel
 
 from test_generator import get_random_generator, get_random_amorphous_generator
 from test_scene import get_random_scene, get_random_object
-from test_volume import get_random_volume
 
 from czone.blueprint import Blueprint, Serializer
 
@@ -57,16 +56,17 @@ class Test_Blueprint(czone_TestCase):
 
     def test_scene(self):
         for _ in range(self.N_trials):
-            S = get_random_scene()
-            blueprint = Blueprint(S)
-            self.assertEqual(S, blueprint.to_object())
+            for periodic in [False, True]:
+                S = get_random_scene(periodic=periodic)
+                blueprint = Blueprint(S)
+                self.assertEqual(S, blueprint.to_object())
 
 class Test_Serializer(czone_TestCase):
     """blueprint -> serialized form -> blueprint"""
     def setUp(self):
-        self.N_trials = 32
+        self.N_trials = 16
         # self.formats = ['h5', 'json']
-        self.formats = ['json', 'yaml']
+        self.formats = ['json', 'yaml', 'toml']
         self.generator_args = {'with_strain':False, 'with_sub':False}
 
     def test_generator(self):
@@ -95,11 +95,12 @@ class Test_Serializer(czone_TestCase):
 
     def test_scene(self):
         for _ in range(self.N_trials):
-            S = get_random_scene(generator_args=self.generator_args)
-            blueprint = Blueprint(S)
-            for f in self.formats:
-                test_path = 'scene_test_file' + '.' + f
-                Serializer.write(Path(test_path), blueprint)
+            for periodic in [False, True]:
+                S = get_random_scene(periodic=periodic, generator_args=self.generator_args)
+                blueprint = Blueprint(S)
+                for f in self.formats:
+                    test_path = 'scene_test_file' + '.' + f
+                    Serializer.write(Path(test_path), blueprint)
 
-                test_S = Serializer.read(Path(test_path)).to_object()
-                self.assertEqual(S, test_S)
+                    test_S = Serializer.read(Path(test_path)).to_object()
+                    self.assertEqual(S, test_S)

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -3,6 +3,7 @@ from czone_test_fixtures import czone_TestCase
 import numpy as np
 
 from czone.generator import NullGenerator
+from czone.volume import Voxel
 
 from test_generator import get_random_generator, get_random_amorphous_generator
 from test_scene import get_random_scene, get_random_object
@@ -41,6 +42,16 @@ class Test_Blueprint(czone_TestCase):
     def test_volume(self):
         for _ in range(self.N_trials):
             V = get_random_object()
+            blueprint = Blueprint(V)
+            self.assertEqual(V, blueprint.to_object())
+
+    def test_voxel(self):
+        for _ in range(self.N_trials):
+            bases = rng.normal(size=(3,3))
+            scale = rng.uniform(0.1, 10)
+            origin = rng.uniform(-100, 100, size=(3,))
+
+            V = Voxel(bases, scale, origin)
             blueprint = Blueprint(V)
             self.assertEqual(V, blueprint.to_object())
 

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -2,7 +2,7 @@ from czone_test_fixtures import czone_TestCase
 
 import numpy as np
 
-from test_generator import get_random_generator
+from test_generator import get_random_generator, get_random_amorphous_generator
 from test_scene import get_random_scene
 from test_volume import get_random_volume
 

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -1,0 +1,77 @@
+from czone_test_fixtures import czone_TestCase
+
+import numpy as np
+
+from test_generator import get_random_generator
+from test_scene import get_random_scene
+from test_volume import get_random_volume
+
+from czone.blueprint import Blueprint, Serializer
+
+from pathlib import Path
+
+seed = 9815108923
+rng = np.random.default_rng(seed=seed)
+
+
+class Test_Blueprint(czone_TestCase):
+    """object -> blueprint -> object"""
+    def setUp(self):
+        self.N_trials = 32
+
+    def test_generator(self):
+        for _ in range(self.N_trials):
+            G = get_random_generator()
+            blueprint = Blueprint(G)
+            self.assertEqual(G, blueprint.to_object())
+
+    def test_volume(self):
+        for _ in range(self.N_trials):
+            V = get_random_volume()
+            blueprint = Blueprint(V)
+            self.assertEqual(V, blueprint.to_object())
+
+    def test_scene(self):
+        for _ in range(self.N_trials):
+            S = get_random_scene()
+            blueprint = Blueprint(S)
+            self.assertEqual(S, blueprint.to_object())
+
+class Test_Serializer(czone_TestCase):
+    """blueprint -> serialized form -> blueprint"""
+    def setUp(self):
+        self.N_trials = 32
+        self.formats = ['h5', 'json']
+
+    def test_generator(self):
+        for _ in range(self.N_trials):
+            G = get_random_generator()
+            blueprint = Blueprint(G)
+            for f in self.formats:
+                test_path = 'generator_test_file' + '.' + f
+                Serializer.write(Path(test_path), blueprint)
+
+                test_G = Serializer.read(Path(test_path)).to_object()
+                self.assertEqual(G, test_G)
+
+    def test_volume(self):
+        for _ in range(self.N_trials):
+            V = get_random_volume()
+            blueprint = Blueprint(V)
+            for f in self.formats:
+                test_path = 'volume_test_file' + '.' + f
+                Serializer.write(Path(test_path), blueprint)
+
+                test_V = Serializer.read(Path(test_path)).to_object()
+                self.assertEqual(V, test_V)
+
+    def test_scene(self):
+        for _ in range(self.N_trials):
+            S = get_random_scene()
+            blueprint = Blueprint(S)
+            for f in self.formats:
+                test_path = 'scene_test_file' + '.' + f
+                Serializer.write(Path(test_path), blueprint)
+
+                test_S = Serializer.read(Path(test_path)).to_object()
+                self.assertEqual(S, test_S)

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -2,6 +2,8 @@ from czone_test_fixtures import czone_TestCase
 
 import numpy as np
 
+from czone.generator import NullGenerator
+
 from test_generator import get_random_generator, get_random_amorphous_generator
 from test_scene import get_random_scene
 from test_volume import get_random_volume
@@ -20,8 +22,16 @@ class Test_Blueprint(czone_TestCase):
         self.N_trials = 32
 
     def test_generator(self):
+        n_G = NullGenerator()
+        n_blueprint = Blueprint(n_G)
+        self.assertEqual(n_G, n_blueprint.to_object())
+
         for _ in range(self.N_trials):
-            G = get_random_generator()
+            a_G = get_random_amorphous_generator(rng=rng)
+            a_blueprint = Blueprint(a_G)
+            self.assertEqual(a_G, a_blueprint.to_object())
+
+            G = get_random_generator(rng=rng)
             blueprint = Blueprint(G)
             self.assertEqual(G, blueprint.to_object())
 

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -132,16 +132,19 @@ class Test_Generator(czone_TestCase):
             self.assertArrayEqual(gpos, hpos)
             self.assertArrayEqual(gspecies, hspecies)
 
+def get_random_amorphous_generator(rng=rng):
+    origin = rng.uniform(-10,10, size=(1,3))
+    min_dist = rng.uniform(0.5, 10)
+    density = rng.uniform(0.05, 1.0)
+    species = rng.integers(1,119)
+
+    return AmorphousGenerator(origin, min_dist, density, species)
+
 class Test_AmorphousGenerator(czone_TestCase):
     def setUp(self):
         self.N_trials = 128
 
     def test_init(self):
         for _ in range(self.N_trials):
-            origin = rng.uniform(-10,10, size=(1,3))
-            min_dist = rng.uniform(0.5, 10)
-            density = rng.uniform(0.05, 1.0)
-            species = rng.integers(1,119)
-
-            G = AmorphousGenerator(origin, min_dist, density, species)
+            G = get_random_amorphous_generator()
             self.assertReprEqual(G)

--- a/tests/test_molecule.py
+++ b/tests/test_molecule.py
@@ -210,18 +210,6 @@ class Test_Molecule(czone_TestCase):
         f_set_origin = lambda x: mol_0.set_origin(idx=x)
         self.assertRaises(TypeError, f_set_origin, 73.103)
 
-    def test_priority(self):
-        mol = Molecule(np.array([1]), np.zeros((3,1)))
-        for _ in range(self.N_trials):
-            new_priority = rng.integers(-1000,1000)
-            mol.priority = new_priority
-            self.assertEqual(mol.priority, new_priority)
-        
-        def f_set_priority(val):
-            mol.priority = val
-
-        self.assertRaises(TypeError, f_set_priority, 1.0)
-
     def test_transform(self):
         N = 1024
         for _ in range(self.N_trials):
@@ -250,12 +238,3 @@ class Test_Molecule(czone_TestCase):
             mol.print_warnings = val
         
         self.assertRaises(TypeError, set_warnings, 1.2)
-
-    def test_check_interior(self):
-        N = 10
-        species = rng.integers(1,119,(N,1))
-        positions = rng.normal(size=(N,3))            
-        mol = Molecule(species, positions)
-
-        test_pos = rng.normal(size=(N,3))
-        self.assertWarns(UserWarning, mol.checkIfInterior, test_pos)

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -17,17 +17,19 @@ from test_volume import get_random_volume
 from test_generator import get_random_generator
 
 
-def get_random_object(rng=rng):
-    vol_type = rng.choice(['Volume', 'MultiVolume'])
+def get_random_object(rng=rng, depth=0):
+    if depth < 2:
+        vol_type = rng.choice(['Volume', 'MultiVolume'])
+    else:
+        vol_type = 'Volume'
 
     match vol_type:
         case 'Volume':
             G = get_random_generator(rng=rng)
             V = get_random_volume(G, N_points=8, rng=rng)
         case 'MultiVolume':
-            N_vols = rng.integers(2,8)
-            Gs = [get_random_generator(rng=rng) for _ in range(N_vols)]
-            Vs = [get_random_volume(N_points=8, generator=g, rng=rng) for g in Gs]
+            N_vols = rng.integers(2,8 - 3*depth)
+            Vs = [get_random_object(rng, depth=depth+1) for _ in range(N_vols)]
             V  = MultiVolume(Vs, priority=rng.integers(-10,10))
             
     return V

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -17,7 +17,7 @@ from test_volume import get_random_volume
 from test_generator import get_random_generator
 
 
-def get_random_object(rng=rng, depth=0):
+def get_random_object(rng=rng, depth=0, generator_args={}):
     if depth < 2:
         vol_type = rng.choice(['Volume', 'MultiVolume'])
     else:
@@ -25,27 +25,27 @@ def get_random_object(rng=rng, depth=0):
 
     match vol_type:
         case 'Volume':
-            G = get_random_generator(rng=rng)
+            G = get_random_generator(rng=rng, **generator_args)
             V = get_random_volume(G, N_points=8, rng=rng)
         case 'MultiVolume':
             N_vols = rng.integers(2,8 - 3*depth)
-            Vs = [get_random_object(rng, depth=depth+1) for _ in range(N_vols)]
+            Vs = [get_random_object(rng, depth=depth+1, generator_args=generator_args) for _ in range(N_vols)]
             V  = MultiVolume(Vs, priority=rng.integers(-10,10))
             
     return V
 
-def get_random_domain():
+def get_random_domain(rng=rng):
     bases = rng.normal(size=(3,3))
     scale = rng.uniform(0.1, 10)
     origin = rng.uniform(-100, 100, size=(3,))
 
     return Voxel(bases, scale, origin)
 
-def get_random_scene(periodic=False, N_max_objects=8, rng=rng,):
+def get_random_scene(periodic=False, N_max_objects=8, rng=rng, generator_args={}):
     
     N_objects = rng.integers(1, N_max_objects)
-    domain = get_random_domain()
-    objects = [get_random_object() for _ in range(N_objects)]
+    domain = get_random_domain(rng=rng)
+    objects = [get_random_object(rng=rng, generator_args=generator_args) for _ in range(N_objects)]
 
     if periodic:
         pbc = tuple((bool(rng.choice([True, False])) for _ in range(3)))


### PR DESCRIPTION
This PR adds a new top level module to Construction Zone: the Blueprints module.

The Blueprints module primarily consists of two main submodules: the `Blueprint`s themselves, and a collections of `Serializer`s. Together, these two submodules allow us to 1) generate a consistent, internal hierarchical tree representation of any CZ object and 2) read and write these tree representations directly to/from disk. This specifically lets us save arbitrary Generators, Volumes, and Scenes to disk in a reproducible format, allowing us to separate the creation of nanoscale objects from the actual generation of the atomic scene in computation.

Current supported formats are json, yaml, toml, and h5py--out of the box, json is supported with the use of Python's stdlib json module; other formats require (relatively light-weight) third-party dependencies.